### PR TITLE
chore: add destroy_all to seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,4 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+{Model}.destroy_all 


### PR DESCRIPTION
# Description
Add destroy_all to seed data for pushes to render.  Render will seed data each deployment.

<br>

## Type of Changes:

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Testing


<br>
<br>

# Related Issue(s):

- [x]  closes #3 

<br>

## Other Considerations 

- [ ] I have linted my code locally before submission
- [ ] This change requires a documentation update
